### PR TITLE
Fix: Use correct listener methods

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,8 +23,8 @@ export default () => {
     Keyboard.addListener('keyboardDidHide', onKeyboardDidHide);
 
     return () => {
-      Keyboard.removeListener('keyboardDidShow');
-      Keyboard.removeListener('keyboardDidHide');
+      Keyboard.removeListener('keyboardDidShow', onKeyboardDidShow);
+      Keyboard.removeListener('keyboardDidHide', onKeyboardDidHide);
     };
   }, []);
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,12 +19,12 @@ export default () => {
       setVisible(false);
     }
 
-    Keyboard.addEventListener('keyboardDidShow', onKeyboardDidShow);
-    Keyboard.addEventListener('keyboardDidHide', onKeyboardDidHide);
+    Keyboard.addListener('keyboardDidShow', onKeyboardDidShow);
+    Keyboard.addListener('keyboardDidHide', onKeyboardDidHide);
 
     return () => {
-      Keyboard.removeEventListener('keyboardDidShow', onKeyboardDidShow);
-      Keyboard.removeEventListener('keyboardDidHide', onKeyboardDidHide);
+      Keyboard.removeListener('keyboardDidShow');
+      Keyboard.removeListener('keyboardDidHide');
     };
   }, []);
 


### PR DESCRIPTION
As outlined in the [Keyboard documentation](https://facebook.github.io/react-native/docs/keyboard) - the method names are `addListener` and `removeListener`.