### PR TITLE
feat: support willShow / willHide events

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,27 @@ function App() {
 
 ```
 
+### Configuration
+
+If you like, you can configure the hook to use the `will` events instead of the
+`did` events (by default, it uses the `did` events). This is useful in cases
+where you want to trigger an animation before the keyboard begins dismissing:
+
+```js
+useKeyboard({
+  useWillShow: true,
+  useWillHide: true,
+})
+```
+
+| Name        | Default | Type    | Description                               |
+| ----------- | ------- | -------:| ----------------------------------------- |
+| useWillShow | `false` | boolean | Use the `keyboardWillShow` event instead. |
+| useWillHide | `false` | boolean | Use the `keyboardWillHide` event instead. |
+
 ### Output
 
 | Name    | Default             | Type     | Description         |
 | ------- | ------------------- | --------:| ------------------- |
 | visible | `false`             | boolean  | Keyboard Visibility |
 | dismiss | `Keyboard.dismiss`  | function | Dismiss Keyboard    |
-

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,11 @@
 import React, { useEffect, useState } from 'react';
 import { Keyboard } from 'react-native';
 
-export default () => {
+export default (config = {}) => {
+  const { useWillShow = false, useWillHide = false } = config;
   const [visible, setVisible] = useState(false);
+  const showEvent = useWillShow ? 'keyboardWillShow' : 'keyboardDidShow';
+  const hideEvent = useWillHide ? 'keyboardWillHide' : 'keyboardDidHide';
 
   function dismiss() {
     Keyboard.dismiss();
@@ -11,22 +14,22 @@ export default () => {
   }
 
   useEffect(() => {
-    function onKeyboardDidShow() {
+    function onKeyboardShow() {
       setVisible(true);
     }
 
-    function onKeyboardDidHide() {
+    function onKeyboardHide() {
       setVisible(false);
     }
 
-    Keyboard.addListener('keyboardDidShow', onKeyboardDidShow);
-    Keyboard.addListener('keyboardDidHide', onKeyboardDidHide);
+    Keyboard.addListener(showEvent, onKeyboardShow);
+    Keyboard.addListener(hideEvent, onKeyboardHide);
 
     return () => {
-      Keyboard.removeListener('keyboardDidShow', onKeyboardDidShow);
-      Keyboard.removeListener('keyboardDidHide', onKeyboardDidHide);
+      Keyboard.removeListener(showEvent, onKeyboardShow);
+      Keyboard.removeListener(hideEvent, onKeyboardHide);
     };
-  }, []);
+  }, [useWillShow, useWillHide]);
 
   return [visible, dismiss];
 };


### PR DESCRIPTION
Built and tested on the project I'm currently working on. Adds a new options object to the hook:

```js
useKeyboard({
  useWillShow: true,
  useWillHide: true,
})
```

Split up into two different options because in my case I wanted to start setting the height immediately after the keyboard started opening, and wait to reset it until after the keyboard had closed.